### PR TITLE
feature(2847512320): Adjust ID values types as string

### DIFF
--- a/src/lib/gateway/gateway-request.ts
+++ b/src/lib/gateway/gateway-request.ts
@@ -2,6 +2,7 @@ import {GatewayRequestType} from './gateway-request-type';
 import {
   FeeInfoExchangeRequest,
   FeeInfoUserRequest,
+  NumericSequence,
   OrderRequest,
   Signature
 } from './gateway-types';
@@ -16,11 +17,11 @@ type GatewayRequest =
   | MultiTransactionRequest;
 
 interface Request {
-  txId: number;
+  txId: NumericSequence;
 }
 
 interface WithVault {
-  vaultId: number;
+  vaultId: NumericSequence;
 }
 
 interface WithStarkKey {
@@ -28,8 +29,8 @@ interface WithStarkKey {
 }
 
 interface WithAmount {
-  tokenId: string;
-  amount: number;
+  tokenId: NumericSequence;
+  amount: NumericSequence;
 }
 
 interface TransactionRequest
@@ -45,14 +46,14 @@ interface FalseFullWithdrawalRequest extends Request, WithVault {
 }
 
 interface TransferRequest extends Request {
-  amount: number;
-  nonce: number;
+  amount: NumericSequence;
+  nonce: NumericSequence;
   senderPublicKey: string;
-  senderVaultId: number;
+  senderVaultId: NumericSequence;
   token: string;
   receiverPublicKey: string;
-  receiverVaultId: number;
-  expirationTimestamp: number;
+  receiverVaultId: NumericSequence;
+  expirationTimestamp: NumericSequence;
   signature: Signature;
   feeInfoUser?: FeeInfoUserRequest;
   feeInfoExchange?: FeeInfoExchangeRequest;

--- a/src/lib/gateway/gateway-types.ts
+++ b/src/lib/gateway/gateway-types.ts
@@ -1,12 +1,16 @@
+// Represents a numeric (only) sequence to hold numbers 
+// that cannot fit into the build-in JS number type
+type NumericSequence = number | string;
+
 interface OrderRequest {
   orderType: OrderTypeObsolete;
-  nonce: number;
-  amountSell: number;
-  amountBuy: number;
+  nonce: NumericSequence;
+  amountSell: NumericSequence;
+  amountBuy: NumericSequence;
   tokenSell: string;
   tokenBuy: string;
-  vaultIdSell: number;
-  vaultIdBuy: number;
+  vaultIdSell: NumericSequence;
+  vaultIdBuy: NumericSequence;
   expirationTimestamp: number;
   feeInfo?: FeeInfoUserRequest;
 }
@@ -18,13 +22,13 @@ interface Signature {
 
 interface FeeInfoUserRequest {
   feeLimit: number;
-  sourceVaultId: number;
-  tokenId: string;
+  sourceVaultId: NumericSequence;
+  tokenId: NumericSequence;
 }
 
 interface FeeInfoExchangeRequest {
   destinationStarkKey: string;
-  destinationVaultId: number;
+  destinationVaultId: NumericSequence;
   feeTaken: number;
 }
 
@@ -34,6 +38,7 @@ enum OrderTypeObsolete {
 }
 
 export {
+  NumericSequence,
   OrderRequest,
   Signature,
   FeeInfoUserRequest,

--- a/src/lib/gateway/gateway-types.ts
+++ b/src/lib/gateway/gateway-types.ts
@@ -1,4 +1,4 @@
-// Represents a numeric (only) sequence to hold numbers 
+// Represents a numeric (only) sequence to hold numbers
 // that cannot fit into the build-in JS number type
 type NumericSequence = number | string;
 

--- a/src/lib/gateway/gateway-types.ts
+++ b/src/lib/gateway/gateway-types.ts
@@ -1,5 +1,5 @@
 // Represents a numeric (only) sequence to hold numbers
-// that cannot fit into the build-in JS number type
+// that cannot fit into the built-in JS number type
 type NumericSequence = number | string;
 
 interface OrderRequest {

--- a/src/lib/gateway/gateway.ts
+++ b/src/lib/gateway/gateway.ts
@@ -13,6 +13,7 @@ import {
 } from './gateway-request';
 import {GatewayRequestType} from './gateway-request-type';
 import {GatewayServiceType} from './gateway-service-type';
+import {NumericSequence} from './gateway-types';
 
 class Gateway extends GatewayBase {
   constructor(config: StarkExClientConfig) {
@@ -29,7 +30,7 @@ class Gateway extends GatewayBase {
     return this.makeRequest(GatewayServiceType.GET_STARK_DEX_ADDRESS);
   }
 
-  public getFirstUnusedTxId(): Promise<number> {
+  public getFirstUnusedTxId(): Promise<NumericSequence> {
     return this.makeRequest(GatewayServiceType.GET_FIRST_UNUSED_TX_ID);
   }
 


### PR DESCRIPTION
### Description of the Changes

Some values may receive a numbers larger that JS number can hold, so we want to store it a string, yet have an informative way to tell the user that it should be Numeric only.

Solves #[2847512320](https://starkware.monday.com/boards/2847512260/pulses/2847512320)

---

### Checklist

- [ ] New unit / functional tests have been added (whenever applicable).
- [ ] Docs have been updated (whenever relevant).
- [ ] PR title is follow the [Conventional Commits](https://www.conventionalcommits.org/) convention: `<type>[optional scope]: <description>`, e.g: `fix: prevent racing of requests`
