### PR TITLE
feat(2847512320): adjust numeric types

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -154,7 +154,7 @@ _Example for a DepositRequest_
 ```ts
 const request = {
   txId: 10234993,
-  amount: 4029557120079369747,
+  amount: "4029557120079369747",
   starkKey: "0x7c65c1e82e2e662f728b4fa42485e3a0a5d2f346baa9455e3e70682c2094cac",
   tokenId: "0x2dd48fd7a024204f7c1bd874da5e709d4713d60c8a70639eb1167b367a9c378",
   vaultId: 1654615998

--- a/src/lib/gateway/gateway-request.ts
+++ b/src/lib/gateway/gateway-request.ts
@@ -1,6 +1,7 @@
 import {
   FeeInfoExchangeRequest,
   FeeInfoUserRequest,
+  NumericSequence,
   OrderRequest,
   Signature
 } from './gateway-types';
@@ -14,11 +15,11 @@ type GatewayRequest =
   | ConditionalTransferRequest;
 
 interface Request {
-  txId: number;
+  txId: NumericSequence;
 }
 
 interface WithVault {
-  vaultId: number;
+  vaultId: NumericSequence;
 }
 
 interface WithStarkKey {
@@ -27,7 +28,7 @@ interface WithStarkKey {
 
 interface WithAmount {
   tokenId: string;
-  amount: number;
+  amount: string;
 }
 
 interface TransactionRequest
@@ -43,13 +44,13 @@ interface FalseFullWithdrawalRequest extends Request, WithVault {
 }
 
 interface TransferRequest extends Request {
-  amount: number;
-  nonce: number;
+  amount: string;
+  nonce: NumericSequence;
   senderPublicKey: string;
-  senderVaultId: number;
+  senderVaultId: NumericSequence;
   token: string;
   receiverPublicKey: string;
-  receiverVaultId: number;
+  receiverVaultId: NumericSequence;
   expirationTimestamp: number;
   signature: Signature;
   feeInfoUser?: FeeInfoUserRequest;

--- a/src/lib/gateway/gateway-types.ts
+++ b/src/lib/gateway/gateway-types.ts
@@ -1,12 +1,16 @@
+// Represents a numeric (only) sequence to hold numbers
+// that cannot fit into the built-in JS number type
+type NumericSequence = number | string;
+
 interface OrderRequest {
   orderType: OrderTypeObsolete;
-  nonce: number;
-  amountSell: number;
-  amountBuy: number;
+  nonce: NumericSequence;
+  amountSell: string;
+  amountBuy: string;
   tokenSell: string;
   tokenBuy: string;
-  vaultIdSell: number;
-  vaultIdBuy: number;
+  vaultIdSell: NumericSequence;
+  vaultIdBuy: NumericSequence;
   expirationTimestamp: number;
   feeInfo?: FeeInfoUserRequest;
 }
@@ -18,13 +22,13 @@ interface Signature {
 
 interface FeeInfoUserRequest {
   feeLimit: number;
-  sourceVaultId: number;
+  sourceVaultId: NumericSequence;
   tokenId: string;
 }
 
 interface FeeInfoExchangeRequest {
   destinationStarkKey: string;
-  destinationVaultId: number;
+  destinationVaultId: NumericSequence;
   feeTaken: number;
 }
 
@@ -38,5 +42,6 @@ export {
   Signature,
   FeeInfoUserRequest,
   FeeInfoExchangeRequest,
+  NumericSequence,
   OrderTypeObsolete
 };

--- a/test/gateway.spec.js
+++ b/test/gateway.spec.js
@@ -11,7 +11,7 @@ describe('Gateway', () => {
   let starkExAPI, error;
   const vaultId = 1;
   const txId = 1;
-  const amount = 1;
+  const amount = "1";
   const starkKey = '0x2';
   const tokenId = '0x1';
   const nonce = 2;

--- a/test/gateway.spec.js
+++ b/test/gateway.spec.js
@@ -11,7 +11,7 @@ describe('Gateway', () => {
   let starkExAPI, error;
   const vaultId = 1;
   const txId = 1;
-  const amount = "1";
+  const amount = '1';
   const starkKey = '0x2';
   const tokenId = '0x1';
   const nonce = 2;


### PR DESCRIPTION
### Description of the Changes

Some values may receive a numbers larger that JS number can hold, so we want to store it a string, yet have an informative way to tell the user that it should be Numeric only.

Solves #[2847512320](https://starkware.monday.com/boards/2847512260/pulses/2847512320)
---

### Checklist

- [x] New unit / functional tests have been added (whenever applicable).
- [ ] Docs have been updated (whenever relevant).
- [x] PR title is follow the [Conventional Commits](https://www.conventionalcommits.org/) convention: `<type>[optional scope]: <description>`, e.g: `fix: prevent racing of requests`
