### PR TITLE
task(3200371080): feeder gateway - deprecate v1 methods 

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,9 +207,6 @@ console.log(batchIds); // [123, 456]
 
 Full API docs for `feederGateway` can be found [here](docs/classes/FeederGateway.md).
 
----
-
-Note: All results will be exactly the **raw** response from the API.
 
 _Deprecated functionality_
 
@@ -227,6 +224,10 @@ While:
 await starkExAPI.feederGateway.DEDEPRECATED_getBatchInfo(1);
 ```
 will make a request to `/feeder_gateway/get_batch_info`.
+
+---
+
+Note: All results will be exactly the **raw** response from the API.
 
 ## API Docs
 

--- a/README.md
+++ b/README.md
@@ -211,6 +211,23 @@ Full API docs for `feederGateway` can be found [here](docs/classes/FeederGateway
 
 Note: All results will be exactly the **raw** response from the API.
 
+_Deprecated functionality_
+
+Since StarkEx v4.5, `gateway` and `feeder gateway` apis expect to receive http requests for version 2 (`v2` prefix inside the request url).
+
+Deprecated functions, that still uses the old version of the StarkEx api (no url prefix), are marked with a `DEPRECATED` prefix by the SDK. This was done in order to inform the user that even though those methods are still supported by the api, they will be deleted in the next version.
+
+For example, a request to `/v2/feeder_gateway/get_batch_info` will be made by:
+```ts
+await starkExAPI.feederGateway.getBatchInfo(1);
+```
+
+While:
+```ts
+await starkExAPI.feederGateway.DEDEPRECATED_getBatchInfo(1);
+```
+will make a request to `/feeder_gateway/get_batch_info`.
+
 ## API Docs
 
 [Click here](docs/modules.md) for full API documentation.

--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ await starkExAPI.feederGateway.getBatchInfo(1);
 
 While:
 ```ts
-await starkExAPI.feederGateway.DEDEPRECATED_getBatchInfo(1);
+await starkExAPI.feederGateway.DEPRECATED_getBatchInfo(1);
 ```
 will make a request to `/feeder_gateway/get_batch_info`.
 

--- a/src/lib/feeder-gateway/feeder-gateway.ts
+++ b/src/lib/feeder-gateway/feeder-gateway.ts
@@ -37,10 +37,10 @@ class FeederGateway extends GatewayBase {
     );
   }
 
-  public DEDEPRECATED_getBatchInfo(
+  public DEPRECATED_getBatchInfo(
     batchId: number
   ): Promise<Record<string, any>> {
-    this.logger.error(`DEDEPRECATED_getBatchInfo: ${Messages.DEPRECATION}`);
+    this.logger.error(`DEPRECATED_getBatchInfo: ${Messages.DEPRECATION}`);
     return this.makeRequest(
       `${FeederGatewayServiceType.GET_BATCH_INFO}?batch_id=${batchId}`,
       'GET',

--- a/src/lib/feeder-gateway/feeder-gateway.ts
+++ b/src/lib/feeder-gateway/feeder-gateway.ts
@@ -1,4 +1,4 @@
-import {ApiVersion} from '../../utils';
+import {ApiVersion, Messages} from '../../utils';
 import {GatewayBase} from '../gateway-base';
 import {StarkExClientConfig} from '../starkex-client';
 import {BatchIdsRequest} from './feeder-gateway-request';
@@ -26,10 +26,26 @@ class FeederGateway extends GatewayBase {
     );
   }
 
-  public getBatchIds(request: BatchIdsRequest): Promise<number[]> {
+  public DEPRECATED_getBatchIds(request: BatchIdsRequest): Promise<number[]> {
+    this.logger.error(`DEPRECATED_getBatchIds: ${Messages.DEPRECATION}`);
     const {vaultRoot, orderRoot, sequenceNumber} = request;
     return this.makeRequest(
-      `${FeederGatewayServiceType.GET_BATCH_IDS}?vault_root=${vaultRoot}&order_root=${orderRoot}&sequence_number=${sequenceNumber}`
+      `${FeederGatewayServiceType.GET_BATCH_IDS}?vault_root=${vaultRoot}&order_root=${orderRoot}&sequence_number=${sequenceNumber}`,
+      'GET',
+      undefined,
+      ApiVersion.V1
+    );
+  }
+
+  public DEDEPRECATED_getBatchInfo(
+    batchId: number
+  ): Promise<Record<string, any>> {
+    this.logger.error(`DEDEPRECATED_getBatchInfo: ${Messages.DEPRECATION}`);
+    return this.makeRequest(
+      `${FeederGatewayServiceType.GET_BATCH_INFO}?batch_id=${batchId}`,
+      'GET',
+      undefined,
+      ApiVersion.V1
     );
   }
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -2,3 +2,4 @@ export * from './utils';
 export * from './logger';
 export * from './api-request';
 export * from './api-versioning';
+export * from './messages';

--- a/src/utils/messages.ts
+++ b/src/utils/messages.ts
@@ -1,0 +1,6 @@
+const Messages = {
+  DEPRECATION:
+    'This function is deprecated and will be deleted in the next version.'
+};
+
+export {Messages};


### PR DESCRIPTION
### Description of the Changes

Added a `deprecated` prefix and use V1 for deprecated methods.
Added a messages const.

Solves #[3200371080](https://starkware.monday.com/boards/2847512260/pulses/3200371080)

---

### Checklist

- [ ] New unit / functional tests have been added (whenever applicable).
- [x] Docs have been updated (whenever relevant).
- [X] PR title is follow the [Conventional Commits](https://www.conventionalcommits.org/) convention: `<type>[optional scope]: <description>`, e.g: `fix: prevent racing of requests`
