### PR TITLE
chore: generate docs on semantic-release

### DIFF
--- a/release.config.js
+++ b/release.config.js
@@ -80,7 +80,7 @@ module.exports = {
     {
       prepare: () => {
         execSync('npm run docs:generate');
-      },
+      }
     },
     '@semantic-release/changelog',
     [

--- a/release.config.js
+++ b/release.config.js
@@ -1,3 +1,5 @@
+const {execSync} = require('child_process');
+
 module.exports = {
   branches: [
     'master',
@@ -75,6 +77,11 @@ module.exports = {
         }
       }
     ],
+    {
+      prepare: () => {
+        execSync('npm run docs:generate');
+      },
+    },
     '@semantic-release/changelog',
     [
       '@semantic-release/npm',
@@ -85,7 +92,7 @@ module.exports = {
     [
       '@semantic-release/git',
       {
-        assets: ['package.json', 'yarn.lock', 'CHANGELOG.md'],
+        assets: ['package.json', 'yarn.lock', 'CHANGELOG.md', 'docs'],
         message:
           "<%= branch === 'dev' ? 'prerelease' : 'release' %>: <%= nextRelease.gitTag %>\n\n <%= nextRelease.notes %>"
       }


### PR DESCRIPTION
### Description of the Changes

Use a custom plugin to run `npm run docs:generate` and commit docs generated. 

` Docs have been updated?` - they will after this commit.

---

### Checklist

- [ ] New unit / functional tests have been added (whenever applicable).
- [X] Docs have been updated (whenever relevant).
- [X] PR title is follow the [Conventional Commits](https://www.conventionalcommits.org/) convention: `<type>[optional scope]: <description>`, e.g: `fix: prevent racing of requests`
