### PR TITLE
[fix]: fix typecheck

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "@semantic-release/release-notes-generator": "^10.0.2",
     "@trivago/prettier-plugin-sort-imports": "^2.0.4",
     "@types/axios": "^0.14.0",
+    "@types/node": "^20.9.0",
     "@typescript-eslint/eslint-plugin": "^4.29.0",
     "@typescript-eslint/parser": "^4.29.0",
     "babel-eslint": "^10.1.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,8 @@
     "esModuleInterop": true,
     "moduleResolution": "node",
     "resolveJsonModule": true,
-    "allowJs": true
+    "allowJs": true,
+    "lib": ["es2015"]
   },
   "include": ["src/**/*"],
   "exclude": ["playground/**/*"]


### PR DESCRIPTION
Fix the following type check errors,

```text

> @starkware-industries/starkex-js@0.1.0 typecheck
> tsc --noemit

node_modules/.pnpm/@types+eslint-scope@3.7.7/node_modules/@types/eslint-scope/index.d.ts:32:10 - error TS2583: Cannot find name 'Map'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.

32     set: Map<string, Variable>;
            ~~~

node_modules/.pnpm/@types+eslint@8.44.7/node_modules/@types/eslint/index.d.ts:70:14 - error TS2583: Cannot find name 'Map'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.

70         set: Map<string, Variable>;
                ~~~

node_modules/.pnpm/@types+eslint@8.44.7/node_modules/@types/eslint/index.d.ts:787:59 - error TS2304: Cannot find name 'IterableIterator'.

787     type ReportFixer = (fixer: RuleFixer) => null | Fix | IterableIterator<Fix> | Fix[];
                                                              ~~~~~~~~~~~~~~~~

node_modules/.pnpm/@types+eslint@8.44.7/node_modules/@types/eslint/index.d.ts:871:17 - error TS2583: Cannot find name 'Map'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.

871     getRules(): Map<string, Rule.RuleModule>;
                    ~~~

src/lib/gateway-base.ts:55:6 - error TS2705: An async function or method in ES5/ES3 requires the 'Promise' constructor.  Make sure you have a declaration for the 'Promise' constructor or include 'ES2015' in your '--lib' option.

55   ): Promise<any> {
        ~~~~~~~~~~~~

src/lib/gateway-base.ts:68:14 - error TS2585: 'Promise' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the 'lib' compiler option to es2015 or later.

68       return Promise.reject(err.response?.data);
                ~~~~~~~

src/lib/gateway/gateway.ts:132:14 - error TS2585: 'Promise' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the 'lib' compiler option to es2015 or later.

132       return Promise.reject({...err, txId});
                 ~~~~~~~

src/utils/api-request.ts:18:12 - error TS2550: Property 'assign' does not exist on type 'ObjectConstructor'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.

18     Object.assign(config.headers, customHeaders);
              ~~~~~~

src/utils/api-request.ts:21:26 - error TS2585: 'Promise' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the 'lib' compiler option to es2015 or later.

21   (error: AxiosError) => Promise.reject(error)
                            ~~~~~~~

src/utils/api-request.ts:30:26 - error TS2585: 'Promise' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the 'lib' compiler option to es2015 or later.

30   (error: AxiosError) => Promise.reject(error)
                            ~~~~~~~

src/utils/api-request.ts:48:5 - error TS2705: An async function or method in ES5/ES3 requires the 'Promise' constructor.  Make sure you have a declaration for the 'Promise' constructor or include 'ES2015' in your '--lib' option.

48 }): Promise<AxiosResponse> => {
       ~~~~~~~~~~~~~~~~~~~~~~

src/utils/api-request.ts:52:19 - error TS2580: Cannot find name 'require'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.

52     const https = require('https');
                     ~~~~~~~

src/utils/api-request.ts:59:21 - error TS2550: Property 'assign' does not exist on type 'ObjectConstructor'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.

59     headers: Object.assign({}, DEFAULT_HEADERS, headers),
                       ~~~~~~

Found 13 errors in 5 files.

```