### PR TITLE
docs: MultiTransaction example references an undefined `starkExClient`

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,18 +164,18 @@ console.log(response); // {txId: 10234993, code: "TRANSACTION_PENDING"}
 _Example for a MultiTransactionRequest_
 
 ```ts
-const response = await starkExClient.gateway.multiTransaction({
+const response = await starkExAPI.gateway.multiTransaction({
   txId: 10234994,
   txs: [
     {
-      type: StarkExClient.GatewayRequestType.DEPOSIT_REQUEST,
+      type: StarkExAPI.GatewayRequestType.DEPOSIT_REQUEST,
       amount: "4029557120079369747",
       starkKey: "0x7c65c1e82e2e662f728b4fa42485e3a0a5d2f346baa9455e3e70682c2094cac",
       tokenId: "0x2dd48fd7a024204f7c1bd874da5e709d4713d60c8a70639eb1167b367a9c378",
       vaultId: 1654615998
     },
     {
-      type: StarkExClient.GatewayRequestType.WITHDRAWAL_REQUEST,
+      type: StarkExAPI.GatewayRequestType.WITHDRAWAL_REQUEST,
       amount: "4029557120079369747",
       starkKey: "0x7c65c1e82e2e662f728b4fa42485e3a0a5d2f346baa9455e3e70682c2094cac",
       tokenId: "0x2dd48fd7a024204f7c1bd874da5e709d4713d60c8a70639eb1167b367a9c378",


### PR DESCRIPTION
## Problem

The README explains that the library is a default export and can be imported under any name, and then consistently uses `StarkExAPI`:

```ts
import StarkExAPI from '@starkware-industries/starkex-js/browser';
...
const starkExAPI = new StarkExAPI({ ... });
```

The MultiTransaction example breaks that convention in three places:

| line | code | problem |
|---|---|---|
| 167 | `await starkExClient.gateway.multiTransaction(...)` | `starkExClient` is never declared — `ReferenceError` |
| 171 | `StarkExClient.GatewayRequestType.DEPOSIT_REQUEST` | `StarkExClient` is not the imported name |
| 178 | `StarkExClient.GatewayRequestType.WITHDRAWAL_REQUEST` | same |

`StarkExClient` is the internal class name (`src/index.ts` does `export default StarkExClient`), so it is what the author had in scope while writing the code — but it is not what a reader following this README has.

The enum reference is otherwise correct: `GatewayRequestType` really is exposed as a static, `src/lib/starkex-client.ts:7`:

```ts
public static readonly GatewayRequestType = GatewayRequestType;
```

so it just needs to hang off the name the README established.

## Fix

`starkExClient` → `starkExAPI`, and `StarkExClient.GatewayRequestType` → `StarkExAPI.GatewayRequestType`. Three lines, README only.

All three lines get shorter, so `prettier --check` (which `yarn lint` runs over `**/*.md`) has nothing to reflow.